### PR TITLE
Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot configuration file
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Keep npm dependencies up to date
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      # Group ALL npm version updates (minor/patch/major) into a single PR
+      npm-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      # Group ALL npm security updates into a single PR
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      actions-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable Dependabot version updates and combined grouping.

## What this does
- Enables weekly version updates for **npm** and **GitHub Actions**
- - Groups ALL npm version updates (minor/patch/major) into a single PR
- - Groups ALL npm security updates into a single PR (via `applies-to: security-updates`)
- - Same grouping for GitHub Actions
- - Limits open PRs to 10
## Related
Dependabot alerts, security updates, and grouped security updates are already enabled at the repo settings level. With the `applies-to: security-updates` group in this config, the existing 82 vulnerability alerts should be bundled into one combined PR rather than opened individually.
